### PR TITLE
fix: add missing test dependencies

### DIFF
--- a/OpenMLE-Evo/pyproject.toml
+++ b/OpenMLE-Evo/pyproject.toml
@@ -21,7 +21,8 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest==8.3.5"]
+dev = ["pytest==8.3.5", "pyyaml>=6.0", "black>=24.0", "omegaconf==2.3.0"]
+test = ["pytest==8.3.5", "pyyaml>=6.0", "black>=24.0", "omegaconf==2.3.0"]
 
 [tool.setuptools.packages.find]
 include = ["tts_search*"]

--- a/OpenMLE-Evo/requirements-test.txt
+++ b/OpenMLE-Evo/requirements-test.txt
@@ -1,0 +1,4 @@
+pytest>=7.0
+pyyaml>=6.0
+black>=23.0
+omegaconf>=2.3


### PR DESCRIPTION
This PR adds the missing test dependencies required to run the OpenMLE-Evo test suite.