### PR TITLE
Fix NatureBench local evaluation contract

### DIFF
--- a/OpenMLE-Evo/benchmarks/naturebench_local_quick/README.md
+++ b/OpenMLE-Evo/benchmarks/naturebench_local_quick/README.md
@@ -69,6 +69,15 @@ export PRIMARY_KEY='your-api-key'
 Credentials are read only from `PRIMARY_KEY`; they are not written into Hydra
 config snapshots.
 
+Current NatureBench releases protect evaluator registration and timer controls
+with a service control token. When this launcher starts the evaluator, it
+creates a private token file under the experiment output and configures the
+controller automatically; the token is not exposed to generated candidate
+code. If reusing an evaluator that was started separately with a non-default
+token path, pass the same path with `--eval-control-token-file PATH`. The
+launcher remains compatible with older NatureBench checkouts that do not use
+control tokens.
+
 ### Self-hosted SGLang model
 
 Start SGLang before starting OpenMLE-Evo. The model path, GPU selection, tensor

--- a/OpenMLE-Evo/scripts/run_naturebench_local.py
+++ b/OpenMLE-Evo/scripts/run_naturebench_local.py
@@ -141,6 +141,51 @@ def _service_is_healthy(host: str, port: int) -> bool:
         return False
 
 
+def _eval_service_supports_control_token(naturebench_repo: Path) -> bool:
+    source = (naturebench_repo / "eval_service.py").read_text(
+        encoding="utf-8", errors="replace"
+    )
+    return "--control-token-file" in source
+
+
+def _resolve_eval_control_token_file(
+    *,
+    naturebench_repo: Path,
+    output_dir: Path,
+    configured: str | None,
+    reusing_service: bool,
+) -> Path | None:
+    if not _eval_service_supports_control_token(naturebench_repo):
+        if configured:
+            raise RuntimeError(
+                "--eval-control-token-file was provided, but this NatureBench "
+                "eval service does not support control tokens"
+            )
+        return None
+
+    if configured:
+        token_path = Path(configured).expanduser().resolve()
+    elif reusing_service:
+        token_path = naturebench_repo / "eval_logs" / "eval_control_token"
+    else:
+        token_path = output_dir / ".eval_service" / "control_token"
+
+    if token_path.exists() and not token_path.read_text(encoding="utf-8").strip():
+        raise RuntimeError(
+            f"NatureBench eval control token file is empty: {token_path}"
+        )
+    if reusing_service and not token_path.is_file():
+        raise RuntimeError(
+            "A current NatureBench eval service is already running, but its "
+            f"control token file is unavailable: {token_path}. Pass the file "
+            "used to start that service with --eval-control-token-file, or use "
+            "a free --eval-port."
+        )
+    if not reusing_service:
+        token_path.parent.mkdir(parents=True, exist_ok=True)
+    return token_path
+
+
 def _find_free_loopback_port(host: str = "127.0.0.1") -> int:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
         listener.bind((host, 0))
@@ -371,6 +416,15 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--eval-port", type=int, default=8321)
     parser.add_argument("--eval-start-timeout", type=float, default=30)
     parser.add_argument(
+        "--eval-control-token-file",
+        default=None,
+        help=(
+            "Control-token file used by a current NatureBench eval service. "
+            "For a service started by this launcher, a private file under the "
+            "experiment output is used automatically."
+        ),
+    )
+    parser.add_argument(
         "--model-id",
         default=None,
         help="Model ID exposed by the OpenAI-compatible endpoint (the SGLang --served-model-name value).",
@@ -554,7 +608,14 @@ def main() -> None:
             model_id = _select_model_id(model_id, available)
             print(f"Using model {model_id} at {model_base_url}", flush=True)
 
-        if _service_is_healthy(args.eval_host, args.eval_port):
+        reusing_eval_service = _service_is_healthy(args.eval_host, args.eval_port)
+        eval_control_token_file = _resolve_eval_control_token_file(
+            naturebench_repo=naturebench_repo,
+            output_dir=output_dir,
+            configured=args.eval_control_token_file,
+            reusing_service=reusing_eval_service,
+        )
+        if reusing_eval_service:
             print(
                 f"Reusing healthy NatureBench eval service at "
                 f"http://{args.eval_host}:{args.eval_port}",
@@ -563,15 +624,20 @@ def main() -> None:
         else:
             eval_log_path = output_dir / "eval_service.log"
             eval_log_handle = eval_log_path.open("a", encoding="utf-8")
+            eval_command = [
+                str(runtime_python),
+                str(naturebench_repo / "eval_service.py"),
+                "--host",
+                args.eval_host,
+                "--port",
+                str(args.eval_port),
+            ]
+            if eval_control_token_file is not None:
+                eval_command.extend(
+                    ["--control-token-file", str(eval_control_token_file)]
+                )
             eval_process = subprocess.Popen(
-                [
-                    str(runtime_python),
-                    str(naturebench_repo / "eval_service.py"),
-                    "--host",
-                    args.eval_host,
-                    "--port",
-                    str(args.eval_port),
-                ],
+                eval_command,
                 cwd=naturebench_repo,
                 stdout=eval_log_handle,
                 stderr=subprocess.STDOUT,
@@ -590,6 +656,25 @@ def main() -> None:
                 f"Started local NatureBench eval service at "
                 f"http://{args.eval_host}:{args.eval_port}",
                 flush=True,
+            )
+
+        if eval_control_token_file is not None:
+            try:
+                control_token = eval_control_token_file.read_text(
+                    encoding="utf-8"
+                ).strip()
+            except OSError as exc:
+                raise RuntimeError(
+                    "NatureBench eval service became healthy without a readable "
+                    f"control token file: {eval_control_token_file}"
+                ) from exc
+            if not control_token:
+                raise RuntimeError(
+                    "NatureBench eval service control token file is empty: "
+                    f"{eval_control_token_file}"
+                )
+            child_env["NATUREBENCH_EVAL_CONTROL_TOKEN_FILE"] = str(
+                eval_control_token_file
             )
 
         command = [

--- a/OpenMLE-Evo/tests/test_naturebench_integration.py
+++ b/OpenMLE-Evo/tests/test_naturebench_integration.py
@@ -781,6 +781,127 @@ def test_naturebench_task_registers_eval_service_once_before_evaluation(tmp_path
     }
 
 
+def test_naturebench_task_uses_token_contract_and_rebinds_each_attempt(tmp_path):
+    base_task = _load_module(
+        "naturebench_base_task_token_contract",
+        REPO_ROOT
+        / "third_party"
+        / "aira-evo"
+        / "examples"
+        / "nature_bench"
+        / "base_task.py",
+    )
+
+    control_token_file = tmp_path / "eval-control-token"
+    control_token_file.write_text("service-control-token\n", encoding="utf-8")
+    calls = []
+
+    class TokenContractTask(base_task.NatureBenchTask):
+        def _run_solution(self, code: str, *, phase: str, attempt=None) -> dict:
+            return {
+                "status_code": 0,
+                "status": "success",
+                "raw_run_log": "ran candidate",
+                "clear_run_log": "ran candidate",
+                "feedback": "execution succeeded",
+                "run_time": 0.25,
+                "output_dir": str(attempt.output_dir),
+            }
+
+        def _post_json(
+            self,
+            endpoint: str,
+            payload: dict,
+            *,
+            timeout: int | float,
+        ) -> dict:
+            calls.append((endpoint, dict(payload), timeout))
+            if endpoint in {"register", "start_timer"}:
+                return {"status": "ok"}
+            attempt_number = len([call for call in calls if call[0] == "evaluate"])
+            return {
+                "aggregate_improvement": attempt_number / 10,
+                "best_aggregate_improvement": attempt_number / 10,
+                "raw_scores": {},
+                "per_instance_improvement": {},
+                "attempt": attempt_number,
+            }
+
+    task_package_dir = tmp_path / "task-package"
+    data_dir = task_package_dir / "problem" / "data"
+    data_dir.mkdir(parents=True)
+    task = TokenContractTask(
+        {
+            "benchmark": "naturebench",
+            "task_name": "fake-nature-task",
+            "higher_is_better": True,
+            "data_dir": str(data_dir),
+            "problem_dir": str(data_dir.parent),
+            "task_dir": str(task_package_dir),
+            "workspace_root": str(tmp_path / "workspaces"),
+            "eval_service_url": "http://127.0.0.1:8321",
+            "eval_control_token_file": str(control_token_file),
+            "batch_name": "unit-batch",
+            "execution_mode": "local",
+            "task_description": "Do the fake task.",
+            "data_description": "Use DATA_DIR.",
+            "execution_timeout": 600,
+        },
+        time_budget=14400,
+    )
+
+    state, _ = task.prepare()
+    task.step_task(state, "print('first')")
+    task.step_task(state, "print('second')")
+
+    assert [endpoint for endpoint, _, _ in calls] == [
+        "register",
+        "start_timer",
+        "evaluate",
+        "register",
+        "evaluate",
+    ]
+    registrations = [
+        payload for endpoint, payload, _ in calls if endpoint == "register"
+    ]
+    evaluations = [payload for endpoint, payload, _ in calls if endpoint == "evaluate"]
+    assert registrations[0]["eval_token"] == registrations[1]["eval_token"]
+    assert evaluations == [
+        {
+            "task_name": "fake-nature-task",
+            "batch_name": "unit-batch",
+            "output_dir": str(
+                tmp_path
+                / "workspaces"
+                / "fake-nature-task_validation_1"
+                / "workspace"
+                / "output"
+            ),
+            "eval_token": registrations[0]["eval_token"],
+        },
+        {
+            "task_name": "fake-nature-task",
+            "batch_name": "unit-batch",
+            "output_dir": str(
+                tmp_path
+                / "workspaces"
+                / "fake-nature-task_validation_2"
+                / "workspace"
+                / "output"
+            ),
+            "eval_token": registrations[0]["eval_token"],
+        },
+    ]
+    assert registrations[0]["out_dir"].endswith("fake-nature-task_validation_1")
+    assert registrations[1]["out_dir"].endswith("fake-nature-task_validation_2")
+    assert "force" not in registrations[1]
+    assert task._solution_env(task._workspace_root())["EVAL_SERVICE_URL"]
+    assert (
+        "service-control-token"
+        not in task._solution_env(task._workspace_root()).values()
+    )
+
+
 def test_naturebench_scm_docker_uses_exclusive_gpu_pool_not_all_flag(tmp_path):
     base_task = _load_module(
         "naturebench_base_task_gpu",

--- a/OpenMLE-Evo/tests/test_naturebench_local_runner.py
+++ b/OpenMLE-Evo/tests/test_naturebench_local_runner.py
@@ -3,9 +3,14 @@ from __future__ import annotations
 import importlib.util
 import json
 import os
+import socket
 import subprocess
 import sys
+import time
+import urllib.request
 from pathlib import Path
+
+import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
@@ -119,6 +124,50 @@ def test_local_solution_uses_configured_python(tmp_path):
     assert task.validation_data_dir in result["raw_run_log"]
 
 
+def test_current_eval_contract_adds_control_header_only_to_control_endpoints(
+    monkeypatch,
+    tmp_path,
+):
+    base_task = _base_task_module()
+    control_token_file = tmp_path / "eval-control-token"
+    control_token_file.write_text("private-control-token\n", encoding="utf-8")
+    task = base_task.NatureBenchTask(
+        _task_config(
+            tmp_path,
+            eval_control_token_file=str(control_token_file),
+        )
+    )
+    requests = []
+
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def read(self):
+            return b'{"status":"ok"}'
+
+    def fake_urlopen(request, timeout):
+        requests.append((request, timeout))
+        return FakeResponse()
+
+    monkeypatch.setattr(base_task.urllib.request, "urlopen", fake_urlopen)
+
+    task._post_json("register", {"task_name": "local-test"}, timeout=10)
+    task._post_json("evaluate", {"eval_token": "opaque"}, timeout=10)
+
+    register_headers = {
+        key.lower(): value for key, value in requests[0][0].header_items()
+    }
+    evaluate_headers = {
+        key.lower(): value for key, value in requests[1][0].header_items()
+    }
+    assert register_headers["x-naturebench-control-token"] == "private-control-token"
+    assert "x-naturebench-control-token" not in evaluate_headers
+
+
 def test_local_timeout_terminates_process_group(tmp_path):
     if os.name != "posix":
         return
@@ -182,6 +231,62 @@ def test_local_launcher_helpers_validate_task_packages(tmp_path):
     )
     launcher._verify_task_packages(tmp_path, [task_id])
     assert json.loads(launcher._hydra_list([task_id])) == [task_id]
+
+
+def test_local_launcher_selects_control_token_file_for_current_service(tmp_path):
+    launcher = _load_module(
+        "naturebench_local_launcher_control_token",
+        REPO_ROOT / "scripts" / "run_naturebench_local.py",
+    )
+    naturebench_repo = tmp_path / "NatureBench"
+    naturebench_repo.mkdir()
+    (naturebench_repo / "eval_service.py").write_text(
+        'parser.add_argument("--control-token-file")\n',
+        encoding="utf-8",
+    )
+    output_dir = tmp_path / "output"
+
+    new_service_token = launcher._resolve_eval_control_token_file(
+        naturebench_repo=naturebench_repo,
+        output_dir=output_dir,
+        configured=None,
+        reusing_service=False,
+    )
+    assert new_service_token == output_dir / ".eval_service" / "control_token"
+
+    default_token = naturebench_repo / "eval_logs" / "eval_control_token"
+    default_token.parent.mkdir()
+    default_token.write_text("existing-token\n", encoding="utf-8")
+    reused_token = launcher._resolve_eval_control_token_file(
+        naturebench_repo=naturebench_repo,
+        output_dir=output_dir,
+        configured=None,
+        reusing_service=True,
+    )
+    assert reused_token == default_token
+
+
+def test_local_launcher_rejects_current_service_without_readable_control_token(
+    tmp_path,
+):
+    launcher = _load_module(
+        "naturebench_local_launcher_missing_control_token",
+        REPO_ROOT / "scripts" / "run_naturebench_local.py",
+    )
+    naturebench_repo = tmp_path / "NatureBench"
+    naturebench_repo.mkdir()
+    (naturebench_repo / "eval_service.py").write_text(
+        'parser.add_argument("--control-token-file")\n',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(RuntimeError, match="control token"):
+        launcher._resolve_eval_control_token_file(
+            naturebench_repo=naturebench_repo,
+            output_dir=tmp_path / "output",
+            configured=None,
+            reusing_service=True,
+        )
 
 
 def test_local_quick_example_targets_only_counterfactual_task():
@@ -275,3 +380,130 @@ def test_local_launcher_builds_ssh_model_tunnel_and_hydra_overrides():
         "litellm.model_list.0.litellm_params.model=openai/served-model",
         "litellm.model_list.0.litellm_params.base_url=http://127.0.0.1:31010/v1",
     ]
+
+
+def test_local_adapter_against_current_naturebench_service(tmp_path):
+    naturebench_repo_value = os.environ.get("NATUREBENCH_REPO")
+    if not naturebench_repo_value:
+        pytest.skip("set NATUREBENCH_REPO to run the external contract test")
+    naturebench_repo = Path(naturebench_repo_value).expanduser().resolve()
+    eval_service = naturebench_repo / "eval_service.py"
+    if not eval_service.is_file():
+        pytest.skip(f"NatureBench eval service is unavailable: {eval_service}")
+
+    task_dir = tmp_path / "task-package"
+    data_dir = task_dir / "problem" / "data"
+    evaluation_dir = task_dir / "evaluation"
+    data_dir.mkdir(parents=True)
+    evaluation_dir.mkdir()
+    (task_dir / "metadata.json").write_text(
+        json.dumps(
+            {
+                "performance_entries": [
+                    {
+                        "dataset_name": "fake-instance",
+                        "metrics": [
+                            {
+                                "name": "accuracy",
+                                "is_primary": True,
+                                "metric_direction": "higher_is_better",
+                                "sota_score": 0.5,
+                            }
+                        ],
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    (evaluation_dir / "evaluator.py").write_text(
+        "import json\n"
+        "import os\n"
+        "from pathlib import Path\n\n"
+        "def run_evaluation():\n"
+        "    score_path = Path(os.environ['OUTPUT_DIR']) / 'score.json'\n"
+        "    score = json.loads(score_path.read_text())['score']\n"
+        "    return {'fake-instance': {'accuracy': score}}\n",
+        encoding="utf-8",
+    )
+    control_token_file = tmp_path / "control-token"
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
+        listener.bind(("127.0.0.1", 0))
+        port = int(listener.getsockname()[1])
+    service = subprocess.Popen(
+        [
+            sys.executable,
+            str(eval_service),
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(port),
+            "--control-token-file",
+            str(control_token_file),
+        ],
+        cwd=naturebench_repo,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    try:
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline:
+            try:
+                with urllib.request.urlopen(
+                    f"http://127.0.0.1:{port}/health", timeout=0.5
+                ) as response:
+                    if response.status == 200:
+                        break
+            except OSError:
+                pass
+            if service.poll() is not None:
+                break
+            time.sleep(0.05)
+        else:
+            pytest.fail("current NatureBench eval service did not become healthy")
+        assert service.poll() is None
+
+        task = _base_task_module().NatureBenchTask(
+            _task_config(
+                tmp_path,
+                task_name="current-contract-test",
+                task_dir=str(task_dir),
+                data_dir=str(data_dir),
+                problem_dir=str(data_dir.parent),
+                eval_service_url=f"http://127.0.0.1:{port}",
+                eval_control_token_file=str(control_token_file),
+                local_python=sys.executable,
+                batch_name="current-contract-batch",
+            ),
+            time_budget=60,
+        )
+        candidate = (
+            "import json, os\n"
+            "from pathlib import Path\n"
+            "output = Path(os.environ['OUTPUT_DIR'])\n"
+            "output.mkdir(parents=True, exist_ok=True)\n"
+            "(output / 'score.json').write_text(json.dumps({'score': SCORE}))\n"
+        )
+        first = task.evaluate_code(
+            candidate.replace("SCORE", "0.8"), phase="validation"
+        )
+        second = task.evaluate_code(
+            candidate.replace("SCORE", "0.6"), phase="validation"
+        )
+
+        assert first["aggregate_improvement"] == pytest.approx(0.6)
+        assert second["aggregate_improvement"] == pytest.approx(0.2)
+        assert second["best_aggregate_improvement"] == pytest.approx(0.6)
+        assert first["attempt"] == 1
+        assert second["attempt"] == 2
+        assert Path(first["output_dir"]).parent.name == "workspace"
+        assert Path(second["output_dir"]).parent.name == "workspace"
+        assert first["output_dir"] != second["output_dir"]
+    finally:
+        service.terminate()
+        try:
+            service.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            service.kill()
+            service.wait(timeout=5)

--- a/OpenMLE-Evo/third_party/aira-evo/examples/nature_bench/base_task.py
+++ b/OpenMLE-Evo/third_party/aira-evo/examples/nature_bench/base_task.py
@@ -5,6 +5,7 @@ import hashlib
 import json
 import os
 import re
+import secrets
 import shlex
 import signal
 import subprocess
@@ -48,6 +49,10 @@ _GPU_WAIT_MARKER_RE = re.compile(
 )
 _GPU_WAIT_TIMEOUT_MARKER = "__AIREVO_GPU_WAIT_TIMED_OUT__=1"
 _IMPORT_PREFLIGHT_MARKER = "__AIREVO_IMPORT_PREFLIGHT__="
+_EVAL_CONTROL_TOKEN_HEADER = "X-NatureBench-Control-Token"
+_EVAL_CONTROL_ENDPOINTS = frozenset(
+    {"register", "start_timer", "resume_timer", "pause_timer"}
+)
 _CANDIDATE_ENV_ALLOWLIST = frozenset(
     {
         "CUDA_VISIBLE_DEVICES",
@@ -90,6 +95,11 @@ class NatureBenchTask(Task):
         self.evaluation_protocol = "naturebench"
         self.execution_mode = str(self.cfg.get("execution_mode", "docker")).lower()
         self.eval_service_url = str(self.cfg["eval_service_url"]).rstrip("/")
+        self.eval_control_token_file = str(
+            self.cfg.get("eval_control_token_file")
+            or os.environ.get("NATUREBENCH_EVAL_CONTROL_TOKEN_FILE")
+            or ""
+        ).strip()
         self.scm_host = str(self.cfg.get("scm_host") or "")
         self.scm_workspace_root = str(self.cfg.get("scm_workspace_root") or "")
         self.scm_eval_service_url = str(
@@ -139,6 +149,8 @@ class NatureBenchTask(Task):
         self.attempt_index = 0
         self._eval_service_registered = False
         self._eval_service_timer_started = False
+        self._eval_control_token: str | None = None
+        self._eval_token: str | None = None
         self._scm_task_root_cache: str | None = None
         self._import_preflight_cache: dict[str, str | None] = {}
 
@@ -583,6 +595,52 @@ class NatureBenchTask(Task):
             )
         return str(self._eval_service_out_dir())
 
+    def _uses_token_eval_contract(self) -> bool:
+        return bool(self.eval_control_token_file)
+
+    def _load_eval_control_token(self) -> str:
+        if self._eval_control_token is not None:
+            return self._eval_control_token
+        if not self.eval_control_token_file:
+            raise RuntimeError("NatureBench eval control token file is not configured")
+        token_path = Path(self.eval_control_token_file).expanduser()
+        try:
+            token = token_path.read_text(encoding="utf-8").strip()
+        except OSError as exc:
+            raise RuntimeError(
+                f"Could not read NatureBench eval control token file: {token_path}"
+            ) from exc
+        if not token:
+            raise RuntimeError(
+                f"NatureBench eval control token file is empty: {token_path}"
+            )
+        self._eval_control_token = token
+        return token
+
+    def _load_or_create_eval_token(self) -> str:
+        if self._eval_token is not None:
+            return self._eval_token
+        control_token = self._load_eval_control_token()
+        token_path = self._eval_service_out_dir() / "eval_token.txt"
+        token_path.parent.mkdir(parents=True, exist_ok=True)
+        if token_path.is_file():
+            token = token_path.read_text(encoding="utf-8").strip()
+            if token and not secrets.compare_digest(token, control_token):
+                self._eval_token = token
+                return token
+
+        token = secrets.token_urlsafe(32)
+        while secrets.compare_digest(token, control_token):
+            token = secrets.token_urlsafe(32)
+        temporary_path = token_path.with_name(
+            f".{token_path.name}.{os.getpid()}.{threading.get_ident()}.tmp"
+        )
+        temporary_path.write_text(token + "\n", encoding="utf-8")
+        temporary_path.chmod(0o600)
+        temporary_path.replace(token_path)
+        self._eval_token = token
+        return token
+
     def _solve_timeout_seconds(self) -> int:
         candidates = [
             self.time_budget,
@@ -623,21 +681,31 @@ class NatureBenchTask(Task):
         with self._state_lock:
             self.attempt_index += 1
             attempt_index = self.attempt_index
-        workspace = self._workspace_root() / (
+        attempt_root = self._workspace_root() / (
             f"{self._safe_path_component(self.task_name)}_"
             f"{self._safe_path_component(phase)}_{attempt_index}"
+        )
+        workspace = (
+            attempt_root / "workspace"
+            if self._uses_token_eval_contract()
+            else attempt_root
         )
         output_dir = workspace / "output"
         output_dir.mkdir(parents=True, exist_ok=True)
         scm_workspace = None
         if self._uses_scm():
-            scm_workspace = "/".join(
+            scm_attempt_root = "/".join(
                 [
                     self.scm_workspace_root.rstrip("/"),
                     self._safe_path_component(self.batch_name),
                     self._safe_path_component(self.task_name),
                     f"{self._safe_path_component(phase)}_{attempt_index}",
                 ]
+            )
+            scm_workspace = (
+                f"{scm_attempt_root}/workspace"
+                if self._uses_token_eval_contract()
+                else scm_attempt_root
             )
         return _AttemptContext(
             index=attempt_index,
@@ -970,10 +1038,13 @@ import urllib.request
 
 req = json.loads(sys.stdin.read())
 data = None if req["payload"] is None else json.dumps(req["payload"]).encode("utf-8")
+headers = dict(req.get("headers") or {})
+if data is not None:
+    headers["Content-Type"] = "application/json"
 request = urllib.request.Request(
     req["url"],
     data=data,
-    headers={"Content-Type": "application/json"} if data is not None else {},
+    headers=headers,
     method=req["method"],
 )
 try:
@@ -991,6 +1062,7 @@ except Exception as exc:
             "url": f"{self.scm_eval_service_url}/{endpoint.lstrip('/')}",
             "payload": payload,
             "timeout": timeout,
+            "headers": self._eval_request_headers(endpoint),
         }
         process = self._ssh(
             "python3 -c " + shlex.quote(script),
@@ -1465,10 +1537,12 @@ done
     ) -> dict[str, Any]:
         if self._uses_scm():
             return self._remote_json_request(endpoint, payload, timeout=timeout)
+        headers = {"Content-Type": "application/json"}
+        headers.update(self._eval_request_headers(endpoint))
         request = urllib.request.Request(
             f"{self.eval_service_url}/{endpoint.lstrip('/')}",
             data=json.dumps(payload).encode("utf-8"),
-            headers={"Content-Type": "application/json"},
+            headers=headers,
             method="POST",
         )
         try:
@@ -1481,9 +1555,35 @@ done
                 f"HTTP {exc.code}: {body}"
             ) from exc
 
-    def _ensure_eval_service_registered(self) -> None:
+    def _eval_request_headers(self, endpoint: str) -> dict[str, str]:
+        normalized_endpoint = endpoint.strip("/")
+        if (
+            self._uses_token_eval_contract()
+            and normalized_endpoint in _EVAL_CONTROL_ENDPOINTS
+        ):
+            return {_EVAL_CONTROL_TOKEN_HEADER: self._load_eval_control_token()}
+        return {}
+
+    def _registration_out_dir_for_output(self, output_dir: str | Path) -> str:
+        if not self._uses_token_eval_contract():
+            return self._eval_service_out_dir_value()
+        output_path = Path(str(output_dir))
+        workspace = output_path.parent
+        if output_path.name != "output" or workspace.name != "workspace":
+            raise RuntimeError(
+                "Token-based NatureBench evaluation requires an "
+                "<attempt>/workspace/output directory"
+            )
+        return str(workspace.parent)
+
+    def _ensure_eval_service_registered(
+        self,
+        *,
+        out_dir: str | None = None,
+        refresh: bool = False,
+    ) -> None:
         with self._eval_service_lock:
-            if self._eval_service_registered:
+            if self._eval_service_registered and not refresh:
                 return
             payload: dict[str, Any] = {
                 "task_name": self.task_name,
@@ -1493,10 +1593,15 @@ done
                     else str(Path(self.task_dir).resolve())
                 ),
                 "timeout": self._solve_timeout_seconds(),
-                "out_dir": self._eval_service_out_dir_value(),
+                "out_dir": out_dir or self._eval_service_out_dir_value(),
                 "batch_name": self.batch_name,
             }
-            if bool(self.cfg.get("force_eval_register", False)):
+            if self._uses_token_eval_contract():
+                payload["eval_token"] = self._load_or_create_eval_token()
+            if (
+                bool(self.cfg.get("force_eval_register", False))
+                and not self._eval_service_registered
+            ):
                 payload["force"] = True
             response = self._post_json("register", payload, timeout=10)
             status = response.get("status")
@@ -1519,13 +1624,22 @@ done
             self._eval_service_timer_started = True
 
     def _post_evaluate(self, output_dir: str | Path) -> dict[str, Any]:
-        self._ensure_eval_service_registered()
-        payload = {
-            "task_name": self.task_name,
-            "batch_name": self.batch_name,
-            "output_dir": str(output_dir),
-        }
-        return self._post_json("evaluate", payload, timeout=self.eval_timeout)
+        with self._eval_service_lock:
+            if self._uses_token_eval_contract():
+                self._ensure_eval_service_registered(
+                    out_dir=self._registration_out_dir_for_output(output_dir),
+                    refresh=True,
+                )
+            else:
+                self._ensure_eval_service_registered()
+            payload = {
+                "task_name": self.task_name,
+                "batch_name": self.batch_name,
+                "output_dir": str(output_dir),
+            }
+            if self._uses_token_eval_contract():
+                payload["eval_token"] = self._load_or_create_eval_token()
+            return self._post_json("evaluate", payload, timeout=self.eval_timeout)
 
     def _annotate_eval_payload(
         self,


### PR DESCRIPTION
## Summary

- support current NatureBench control-token and per-task evaluation-token authentication
- create the required per-attempt `<attempt>/workspace/output` layout and re-register each attempt while preserving compatibility with older NatureBench checkouts
- keep service control credentials out of candidate environments and document reuse of externally started evaluators
- add unit, integration, and current-upstream contract regression coverage

Fixes #12.

## Validation

- `python -m pytest -q`: 123 passed, 1 skipped
- current NatureBench external contract test: 1 passed
- local end-to-end smoke with the model served on `l20x-cluster`: registration, timer start, and evaluation all returned HTTP 200 for generated draft/debug attempts
- `black --check` passes for all changed Python files